### PR TITLE
Add sessions management in settings.py

### DIFF
--- a/bacchus/settings.py
+++ b/bacchus/settings.py
@@ -144,3 +144,9 @@ SCRIPTS_DIR = os.path.join(os.path.dirname(BASE_DIR), 'bacchus/scripts')
 BEAT_RESTART_SCRIPT = 'restart_beat.sh'
 
 # CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
+
+# Session management and timeout
+# https://docs.djangoproject.com/en/1.10/topics/http/sessions/
+
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+SESSION_COOKIE_AGE = 5 * 60


### PR DESCRIPTION
For safety reasons, sessions should be terminated after a short timeout (in this pull request, 5 minutes) or when the browser is closed. Is it safe to do this, or there are unexpected side effects?